### PR TITLE
pass children through custom components

### DIFF
--- a/packages/component/src/component_factory.ts
+++ b/packages/component/src/component_factory.ts
@@ -42,9 +42,9 @@ const executeWithContext = <T>(fn: Function<ComponentContext, T>): T => {
 export const createComponent = <P, T extends WNode<Node>>(
   buildDomTree: StatefulDomBuilder<P, T>
 ): DomBuilder<P, T> => {
-  return (props: P): T => {
+  return (props: P, ...children: WNode<Node>[]): T => {
     return executeWithContext<T>((ctx: ComponentContext): T => {
-      const node: T = buildDomTree(ctx, props);
+      const node: T = buildDomTree(ctx, props, ...children);
       ctx.applyDeferredFunctions(node);
       return node;
     });
@@ -69,11 +69,11 @@ export const lazy = <P, T extends WNode<Node>>(
 ): DomBuilder<P, T> => {
   const capturedInjectionScope: ScopedInjectionRegistry =
     globalInjectionScope.fork();
-  return (props: P): T => {
+  return (props: P, ...children: WNode<Node>[]): T => {
     const currentInjectionScope: ScopedInjectionRegistry = globalInjectionScope;
     globalInjectionScope = capturedInjectionScope;
     try {
-      return builder(props);
+      return builder(props, ...children);
     } finally {
       globalInjectionScope = currentInjectionScope;
     }


### PR DESCRIPTION
getting closer to the ideal jsx api, all backed by the dom-dsl:

``` javascript
/** @jsx jsx */

import {TodoModel} from "./todo_model";
import {div, frag, InjectionKey, runApp} from "recoil/packages/dom-dsl";
import {createComponent, IComponentContext} from "recoil/packages/component";
import {jsx, For, If} from "recoil/packages/dom-jsx";
import {createState} from "recoil/packages/atom";

export const modelInjectionKey = Symbol() as InjectionKey<TodoModel>;

const App = createComponent((ctx: IComponentContext, props: Object) => {
  const show = createState(true);

  ctx.runEffect(() => {
    console.log(`show toggled: ${show.get()}`);
  });

  return (<div>
    <button onclick={() => show.update(v => !v)}> toggle If component </button>
    <If when={show}>
      <h3>hello, world</h3>
      <div>
        <p>
          This is an example of a paragraph!
        </p>
      </div>
    </If>
  </div>);
});

runApp(
  document.body,
  <App class="x"/>
);
```