### PR TITLE
run mount hooks after dom node has been inserted into the doc tree

### DIFF
--- a/examples/code-splitting/app/app.ts
+++ b/examples/code-splitting/app/app.ts
@@ -1,9 +1,9 @@
-import {div, suspense, lazy, button, ifElse} from "recoiljs-dom-dsl";
+import { div, suspense, lazy, button, ifElse } from "recoiljs-dom-dsl";
 import { WNode } from "recoiljs-dom";
-import {createState} from "recoiljs-atom";
+import { createState } from "recoiljs-atom";
 
 const someArbitrarilyLargeComponent = lazy(async () => {
-  await new Promise(res => setTimeout(res, 1000));
+  await new Promise((res) => setTimeout(res, 1000));
   return import("./split_component");
 });
 
@@ -11,16 +11,22 @@ export const app = (): WNode<Node> => {
   const isLargeComponentVisible = createState(false);
 
   const handleButtonClick = (e: Event) => {
-    isLargeComponentVisible.update(v => !v);
+    isLargeComponentVisible.update((v) => !v);
   };
 
-  return div({ className: "wrapper-div" },
-    button({onclick: handleButtonClick, disabled: isLargeComponentVisible},
-      "Show Large Component",
+  return div(
+    { className: "wrapper-div" },
+    button(
+      { onclick: handleButtonClick, disabled: isLargeComponentVisible },
+      "Show Large Component"
     ),
     ifElse({
       condition: isLargeComponentVisible,
-      ifTrue: () => suspense({ fallback: div("loading....") }, someArbitrarilyLargeComponent()),
+      ifTrue: () =>
+        suspense(
+          { fallback: div("loading....") },
+          someArbitrarilyLargeComponent()
+        ),
     })
   );
 };

--- a/packages/dom-dsl/lib/element.ts
+++ b/packages/dom-dsl/lib/element.ts
@@ -201,7 +201,6 @@ export const summary = createDslElementHelper("summary");
 export const audio = createDslElementHelper("audio");
 export const img = createDslElementHelper("img");
 
-
 export const frag = (...children: WNode<Node>[]): WNode<Node> =>
   createFragment(children);
 

--- a/packages/dom-dsl/lib/index.ts
+++ b/packages/dom-dsl/lib/index.ts
@@ -5,5 +5,5 @@ export { match } from "./control/match";
 export * from "./element";
 export { suspense } from "./control/suspense";
 export { runApp } from "recoiljs-dom";
-export {lazy} from "shared";
-export {DefaultModuleType} from "shared";
+export { lazy } from "shared";
+export { DefaultModuleType } from "shared";

--- a/packages/dom-jsx/lib/index.ts
+++ b/packages/dom-jsx/lib/index.ts
@@ -2,5 +2,5 @@ export * from "./control";
 export * from "./jsx";
 export * from "./text";
 export { runApp } from "recoiljs-dom";
-export {lazy} from "shared";
-export {DefaultModuleType} from "shared";
+export { lazy } from "shared";
+export { DefaultModuleType } from "shared";

--- a/packages/dom/lib/api.ts
+++ b/packages/dom/lib/api.ts
@@ -51,7 +51,5 @@ export const createTextNode = (text: string): WNode<Text> => {
 };
 
 export const runApp = (anchor: HTMLElement, app: WNode<Node>): void => {
-  wrapElement(anchor)
-    .bindScopeToWrappedNode()
-    .setChildren([app]);
+  wrapElement(anchor).bindScopeToWrappedNode().setChildren([app]);
 };

--- a/packages/dom/lib/index.ts
+++ b/packages/dom/lib/index.ts
@@ -1,4 +1,4 @@
 export { WNode, isWNode } from "./node";
 export { WElement } from "./element";
 export * from "./api";
-export {wrapTextInWNode} from "./util";
+export { wrapTextInWNode } from "./util";

--- a/packages/dom/lib/node.ts
+++ b/packages/dom/lib/node.ts
@@ -72,11 +72,15 @@ export abstract class BaseWNode<A extends Node, B extends BaseWNode<A, B>> {
     // sync mount status of new children to this dom node
     newChildren.forEach((nc: WNode<Node>): void => {
       nc.setParent(this);
-      this.syncMountStatusOfChild(nc);
     });
+
+    const syncMountStatusOfNewChildren = () => {
+      newChildren.forEach((c) => this.syncMountStatusOfChild(c));
+    };
 
     if (this.isFragment()) {
       this.getParent()?.rebindChildren();
+      syncMountStatusOfNewChildren();
       return this as unknown as B;
     }
 
@@ -86,6 +90,8 @@ export abstract class BaseWNode<A extends Node, B extends BaseWNode<A, B>> {
       newNodes: this.getUnpackedChildren(),
     });
 
+
+    syncMountStatusOfNewChildren();
     return this as unknown as B;
   }
 

--- a/packages/dom/lib/node.ts
+++ b/packages/dom/lib/node.ts
@@ -90,7 +90,6 @@ export abstract class BaseWNode<A extends Node, B extends BaseWNode<A, B>> {
       newNodes: this.getUnpackedChildren(),
     });
 
-
     syncMountStatusOfNewChildren();
     return this as unknown as B;
   }

--- a/packages/dom/lib/reconcile.ts
+++ b/packages/dom/lib/reconcile.ts
@@ -1,6 +1,5 @@
 import { nullOrUndefined } from "shared";
 
-
 /**
  * ISC License
  *
@@ -32,10 +31,10 @@ const frag: DocumentFragment = document.createDocumentFragment();
 // and
 // https://github.com/WebReflection/udomdiff/blob/8923d4fac63a40c72006a46eb0af7bfb5fdef282/index.js
 export const reconcileNodeArrays = ({
-                                      parent,
-                                      currentNodes,
-                                      newNodes,
-                                    }: ReconcileNodeArraysArgs) => {
+  parent,
+  currentNodes,
+  newNodes,
+}: ReconcileNodeArraysArgs) => {
   let curLeft: number = 0;
   let curRight: number = currentNodes.length;
 
@@ -118,7 +117,6 @@ export const reconcileNodeArrays = ({
         ++curLeft;
         ++newLeft;
       }
-
     } else {
       (currentNodes[curLeft] as any).remove();
       ++curLeft;
@@ -130,7 +128,7 @@ export const reconcileNodeArrays = ({
       curLeft < curRight &&
       newLeft < newRight &&
       currentNodes[curLeft] === newNodes[newLeft]
-      ) {
+    ) {
       ++curLeft;
       ++newLeft;
     }
@@ -141,7 +139,7 @@ export const reconcileNodeArrays = ({
       curRight > curLeft &&
       newRight > newLeft &&
       currentNodes[curRight - 1] === newNodes[newRight - 1]
-      ) {
+    ) {
       --curRight;
       --newRight;
     }


### PR DESCRIPTION
You can now select returned items by id etc in the hook - this change makes the intuitive behaviour the default. 